### PR TITLE
Adding new Rev5 catalog with 53A (assessments) data; adjusted readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OSCAL Examples
 
-This directory contains numerous OSCAL examples in XML, JSON, and YAML formats based on the OSCAL 1.0.0 Release Candidate (RC) 2 [release]().
+This directory contains numerous OSCAL examples in XML, JSON, and YAML formats based on the OSCAL 1.0.0 release.
 
 Some examples are considered provisional "finished" versions of OSCAL catalogs and profiles; they are not authoritative but are intended as demonstrations of OSCAL. Other examples are works in progress. Each subdirectory within the examples directory clearly indicates the current status of its example files.
 

--- a/nist.gov/SP800-53/README.md
+++ b/nist.gov/SP800-53/README.md
@@ -8,16 +8,15 @@ OSCAL XML-, JSON-, and YAML-based content is provided for the following SP 800-5
    - an OSCAL control catalog file that captures the SP 800-53 rev 4 and SP 800-53A rev4, combined; and
    - an OSCAL profile file for each of the SP 800-53 rev 4 baselines.
 -  NIST [SP 800-53 Revision 5][sp800-53-rev5] control catalog, and [SP 800-53B][sp800-53B] baselines are provided in OSCAL in [rev5](rev5), as:
-   - an OSCAL controls catalog file that captures the SP 800-53 rev 5;
-   - an OSCAL profile file for each of the SP 800-53B baselines.
-   - a draft version of the NIST SP 800-53 Revision 5 OSCAL catalog including [SP 800-53A][sp800-53A] (draft) content is provided for community review. \[[JSON](rev5/json/draft/NIST_SP-800-53_rev5-800-53A-draft_catalog.json)\] \[[YAML](rev5/yaml/NIST_SP-800-53_rev5_catalog.yaml)\] \[[XML](rev5/xml/draft/NIST_SP-800-53_rev5-800-53A-draft_catalog.xml)\]
-    
+   - an OSCAL controls catalog file that captures the SP 800-53 rev 5. This catalog includes information provided by SP800-53 *Appendix A, Assessment Procedures*;
+   - an OSCAL profile file for each of the SP 800-53B baselines, including the PRIVACY baseline, intended to be used in combination with others to add privacy-oriented controls.
+
 Note: In the SP 800-53 Revision 5, the control catalog and control baselines are published in separate documents. The control baselines are published as [SP 800-53B][sp800-53B].
 
 Please refer to the [publication announcement][sp800-53-rev5-announcement] for more information.
 
 [sp800-53-rev4]: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final
 [sp800-53-rev5]: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
-[sp800-53-rev5-announcement]: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+[sp800-53-rev5-announcement]: https://csrc.nist.gov/News/2022/security-privacy-control-assessment-procedures
 [sp800-53B]: https://csrc.nist.gov/publications/detail/sp/800-53b/final
-[sp800-53A]: https://csrc.nist.gov/publications/detail/sp/800-53a/rev-5/draft
+[sp800-53A]: https://csrc.nist.gov/publications/detail/sp/800-53a/rev-5/final

--- a/nist.gov/SP800-53/README.md
+++ b/nist.gov/SP800-53/README.md
@@ -8,7 +8,7 @@ OSCAL XML-, JSON-, and YAML-based content is provided for the following SP 800-5
    - an OSCAL control catalog file that captures the SP 800-53 rev 4 and SP 800-53A rev4, combined; and
    - an OSCAL profile file for each of the SP 800-53 rev 4 baselines.
 -  NIST [SP 800-53 Revision 5][sp800-53-rev5] control catalog, and [SP 800-53B][sp800-53B] baselines are provided in OSCAL in [rev5](rev5), as:
-   - an OSCAL controls catalog file that captures the SP 800-53 rev 5. This catalog includes information provided by SP800-53 *Appendix A, Assessment Procedures*;
+   - an OSCAL controls catalog file that captures the SP 800-53 rev 5. This catalog includes information provided by SP800-53A *Assessing Security and Privacy Controls in Information Systems and Organizations*;
    - an OSCAL profile file for each of the SP 800-53B baselines, including the PRIVACY baseline, intended to be used in combination with others to add privacy-oriented controls.
 
 Note: In the SP 800-53 Revision 5, the control catalog and control baselines are published in separate documents. The control baselines are published as [SP 800-53B][sp800-53B].


### PR DESCRIPTION
# Committer Notes

OSCAL data in sync with Jan 25 release of Rev 5 with 53A (Assessments)

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
