### PR TITLE
SP800-53 OSCAL content touchup

### DIFF
--- a/src/nist.gov/SP800-53/rev5/xml/validate-labels_SP800-53-catalog.sch
+++ b/src/nist.gov/SP800-53/rev5/xml/validate-labels_SP800-53-catalog.sch
@@ -21,18 +21,18 @@
             <xsl:variable name="expected">
                 <xsl:number count="oscal:part[@name='item']" format="{$number-format}"/>
             </xsl:variable>
-            <sch:assert test=". = $expected">Label issue: expected '<sch:value-of select="$expected"/>'</sch:assert>
+            <sch:assert test="@value = $expected">Label issue: expected '<sch:value-of select="$expected"/>'</sch:assert>
         </sch:rule>
         
         <!-- Preempted by the preceding rule, this rule matches label properties not directly inside part[@name='item'] -->
         <sch:rule context="oscal:prop[@name='label']">
-            <sch:let name="parent-label" value="parent::*/../oscal:prop[@name='label']"/>
+            <sch:let name="parent-label" value="parent::*/../oscal:prop[@name='label'][not(@class='sp800-53a')]"/>
             <!-- returns true() when $parent-label is empty -->
             <sch:assert test="starts-with(.,$parent-label)">Label hierarchy issue</sch:assert>
         </sch:rule>
         
         <sch:rule context="oscal:control">
-            <sch:let name="expected-id" value="o:reduce-label(oscal:prop[@name='label'])"/>
+            <sch:let name="expected-id" value="o:reduce-label(oscal:prop[@name='label'][not(@class='sp800-53a')]/@value)"/>
             <sch:assert test="@id = $expected-id">Expected id to be '<sch:value-of select="$expected-id"/>'</sch:assert>
         </sch:rule>
         
@@ -114,7 +114,7 @@
     </xsl:function>
     
     <xsl:function name="o:reduce-label">
-        <xsl:param name="what"/>
+        <xsl:param name="what" as="node()"/>
         <xsl:value-of select="lower-case($what) ! replace(., '\(', '.') ! replace(., '\)', '') ! replace(.,'\.$','')"/>
     </xsl:function>
     


### PR DESCRIPTION
# Committer Notes

Rectifies ID clashes in new rev5 Assessments contents.

Also repairs broken mapping for **IA-3(3)** parameters, and updates Schematron to the current design wrt part name values etc.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
