### PR TITLE
Fix parameter reference in example basic catalog

### DIFF
--- a/src/examples/catalog/xml/basic-catalog.xml
+++ b/src/examples/catalog/xml/basic-catalog.xml
@@ -36,7 +36,7 @@
             <prop name="label" value="1.1.1"/>
             <part id="s1.1.1_stm" name="statement">
                <p>All information security responsibilities should be defined and allocated.</p>
-               <p>A value has been assigned to <insert type="param" id-ref="s1.1.1-prm11"/>.</p>
+               <p>A value has been assigned to <insert type="param" id-ref="s1.1.1-prm1"/>.</p>
                <p>A cross link has been established with a choppy syntax: <a href="#s1.2">(choppy)</a>.</p>
             </part>
             <part id="s1.1.1_gdn" name="guidance">


### PR DESCRIPTION

# Committer Notes

A parameter does not exist with the id `s1.1.1-prm11`; however, there is
a parameter with the ID `s1.1.1-prm1` which seems to be the intent
within the prose. This updates the ID accordingly.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
