### PR TITLE
Fix broken link to the GSA/fedramp-automation repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These files are maintained by a Continuous Integration and Continuous Deployment
 The structure and contents of the examples directory are as follows:
 
 - [examples](examples): This directory contains sample OSCAL content organized by OSCAL model.
-- [fedramp.gov](fedramp.gov): This directory is now deprecated, please examine [the `baselines` directory in the GSA/fedramp-automation repo](https://github.com/GSA/fedramp-automation/tree/master/baselines) for the canonical copies of the FedRAMP catalog and baseline profiles.
+- [fedramp.gov](fedramp.gov): This directory is now deprecated, please examine [the `baselines` directory in the GSA/fedramp-automation repo](https://github.com/GSA/fedramp-automation/tree/master/dist/content/baselines) for the canonical copies of the FedRAMP catalog and baseline profiles.
 - [nist.gov/SP800-53/rev4](nist.gov/SP800-53/rev4): This directory contains OSCAL examples of the catalog, and low, moderate, and high baselines defined by NIST Special Publication (SP) [800-53 Revision 4](https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final).
 - [nist.gov/SP800-53/rev5](nist.gov/SP800-53/rev5): This directory contains OSCAL examples of the catalog, and low, moderate, and high baselines defined by NIST Special Publication (SP) [800-53 Revision 5](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final[) and [SP 800-53B](https://csrc.nist.gov/publications/detail/sp/800-53b/final) respectively.
   - [nist.gov/SP800-53/rev5/draft](nist.gov/SP800-53/rev5/draft): Earlier releases of draft content for the Final Public Draft (FPD) version of the Revision 5 catalog and baselines. These drafts, are now superseded by the final versions above, and are provided for reference only.


### PR DESCRIPTION
# Committer Notes

It looks like the baselines location was shuffled in
GSA/fedramp-automation. This commit updates it to point to the right
location.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

N/A
