### PR TITLE
Ensure GitHub Actions Installs Python Dependencies Like Local Docker Environment

### DIFF
--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -58,6 +58,17 @@ jobs:
       - name: Get Saxon-HE
         run: |
           mvn org.apache.maven.plugins:maven-dependency-plugin:2.10:get -DartifactId=Saxon-HE -DgroupId=net.sf.saxon -Dversion=$SAXON_VERSION
+      - name: Set up Python 3.x
+        uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6 # current release v3.1.2
+        with:
+          python-version: '3.8'
+          architecture: 'x64'
+          cache: 'pip'
+          cache-dependency-path: |
+            git-content/${{ env.CICD_DIR_PATH }}/python/requirements.txt
+      - name: Install Python dependencies
+        run: |
+          pip install -r "${GITHUB_WORKSPACE}/git-content/${CICD_DIR_PATH}/python/requirements.txt"
       - name: Validate Content
         run:
           # mkdir -p "${OSCAL_BUILD_DIR_PATH}"
@@ -66,13 +77,6 @@ jobs:
       - name: Auto-convert Content
         run:
           bash "${GITHUB_WORKSPACE}/git-content/${CICD_DIR_PATH}/copy-and-convert-content.sh" -o "${GITHUB_WORKSPACE}/git-content/${OSCAL_DIR_PATH}" -a "${GITHUB_WORKSPACE}/git-content" -c "${GITHUB_WORKSPACE}/git-content/${CONTENT_CONFIG_PATH}" -w "${GITHUB_WORKSPACE}/git-content" --resolve-profiles
-      # job-deploy-artifacts
-#      - name: Setup SSH key
-#        # only do this on master in the home repo
-#        if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/master'
-#        run: |
-#          eval "$(ssh-agent -s)"
-#          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
       - name: Publish Artifacts
         # only do this on master
         if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/master'


### PR DESCRIPTION
# Committer Notes

This resolves misalignment between the local developer env for Docker and the managed GitHub Actions for runners where the latter did not install necessary deps for the content conversion script written in Python.

This will close usnistgov/OSCAL#1216 for short-term bug fixing, and long-term improvements will be continued in subsequent systemic improvements tracked in other issues cited in the comment.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- ~Have you added an explanation of what your changes do and why you'd like us to include them?~
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
