### PR TITLE
[skip ci] Add Source Document Defect label.

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -23,4 +23,5 @@
     { "name": "User Story", "color":"5319e7", "description":"The issue is a user story for a development task."},
     { "name": "Waiting for Action", "color":"ef9c6b", "description":"The issue is waiting for the assignee to take some action described in the issue's comments."},
     { "name": "wontfix", "color":"ffffff", "description":"The issue will not be addressed."}
+    { "name": "Source Document Defect", "color":"ee0701", "description":"Track defects in source documents converted into OSCAL and stored in this repo."}
 ]


### PR DESCRIPTION
# Committer Notes

I was tricked into multiples of creating issue labels in this repo only to have them programmatically removed. @david-waltermire-nist wins, I now open pull request. :-)

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- ~Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
