### PR TITLE
Resolve duplicate UUID in example component definition

### DIFF
--- a/src/examples/component-definition/xml/example-component-definition.xml
+++ b/src/examples/component-definition/xml/example-component-definition.xml
@@ -59,7 +59,7 @@
         </description>
       </implemented-requirement>
       <implemented-requirement
-          uuid="cf8338c5-fb6e-4593-a4a8-b3c4946ee2a0"
+          uuid="5227daf8-7a4b-4fe0-aea9-3547b7de2603"
           control-id="sa-4.9">
         <description>
           <p>Must ensure that MongoDB only listens for network


### PR DESCRIPTION
# Committer Notes

The sample component definition for a MongoDB uses a duplicate UUID for
the last two implemented requirements. These should be globally unique.

This may conflict with #82; it seems that the UUIDs have been corrected
in that PR. I wasn't sure if it'd be valuable to have a PR for this
separately from the PR but it's understandable if the preference would
be to close this as a duplicate.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
