### PR TITLE
Fix branch checks for content publication CI/CD.

### DIFF
--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
     branches:
-      - master
+      - main
 name: Process Content Artifacts
 env:
   OSCAL_DIR_PATH: oscal
@@ -24,14 +24,14 @@ jobs:
     steps:
       # use this if checkout needs to be authenticated
       - uses: actions/checkout@v2
-        if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/master'
+        if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/main'
         with:
           path: git-content
           submodules: recursive
           token: ${{ secrets.COMMIT_TOKEN }}
       # use this if checkout is anonymous
       - uses: actions/checkout@v2
-        if: github.repository != env.HOME_REPO || github.ref != 'refs/heads/master'
+        if: github.repository != env.HOME_REPO || github.ref != 'refs/heads/main'
         with:
           path: git-content
           submodules: recursive
@@ -78,8 +78,8 @@ jobs:
         run:
           bash "${GITHUB_WORKSPACE}/git-content/${CICD_DIR_PATH}/copy-and-convert-content.sh" -o "${GITHUB_WORKSPACE}/git-content/${OSCAL_DIR_PATH}" -a "${GITHUB_WORKSPACE}/git-content" -c "${GITHUB_WORKSPACE}/git-content/${CONTENT_CONFIG_PATH}" -w "${GITHUB_WORKSPACE}/git-content" --resolve-profiles
       - name: Publish Artifacts
-        # only do this on master
-        if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/master'
+        # only do this on main
+        if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v4.5.1
         with:
           repository: git-content


### PR DESCRIPTION
# Committer Notes

This is a short-term fix to usnistgov/oscal-content#117 until  usnistgov/oscal-content#116 lands as a more systemic fix.

A test merge and completed run of this minor CI/CD tweak in my main branch of my developer fork can be found in https://github.com/aj-stein-nist/oscal-content/commit/bfe21e16dac9c3e82d90f42e5799ca0aca20078e. This is [workflow run](https://github.com/aj-stein-nist/oscal-content/actions/runs/2672427307) to validate this change will publish accordingly.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
