### PR TITLE
Fixed incorrect party references. Resolves #126.

### DIFF
--- a/src/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
+++ b/src/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
@@ -31,10 +31,10 @@
          </address>
       </party>
       <responsible-party role-id="creator">
-         <party-uuid>c6d77a50-e52e-4399-8a57-896d4807952f</party-uuid>
+         <party-uuid>93122cb0-95bc-4fdb-8b48-85ff60f9509b</party-uuid>
       </responsible-party>
       <responsible-party role-id="contact">
-         <party-uuid>c6d77a50-e52e-4399-8a57-896d4807952f</party-uuid>
+         <party-uuid>93122cb0-95bc-4fdb-8b48-85ff60f9509b</party-uuid>
       </responsible-party>
    </metadata>
    <group class="family" id="ac">


### PR DESCRIPTION
# Committer Notes

Adjusted the `responsible-party` references to use the correct party UUID. Fixes #126.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
