### PR TITLE
Add Content Generation for Develop Branch

### DIFF
--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -77,6 +77,18 @@ jobs:
       - name: Auto-convert Content
         run:
           bash "${GITHUB_WORKSPACE}/git-content/${CICD_DIR_PATH}/copy-and-convert-content.sh" -o "${GITHUB_WORKSPACE}/git-content/${OSCAL_DIR_PATH}" -a "${GITHUB_WORKSPACE}/git-content" -c "${GITHUB_WORKSPACE}/git-content/${CONTENT_CONFIG_PATH}" -w "${GITHUB_WORKSPACE}/git-content" --resolve-profiles
+      - name: Zip Artifacts for Upload
+        if: always()
+        run: |
+          zip ${{ runner.temp }}/generated-content.zip -r .
+        working-directory: ${{ github.workspace }}
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
+        if: always()
+        with:
+          name: generated-content
+          path: |
+            ${{ runner.temp }}/generated-content.zip
+          retention-days: 5
       - name: Publish Artifacts
         # only do this on main
         if: github.repository == env.HOME_REPO && github.ref == 'refs/heads/main'


### PR DESCRIPTION
# Committer Notes

This will close usnistgov/oscal-content#132. I wanted to ensure we share resolved profiles and other content following review and merge of work for usnistgov/oscal-content#97 and lower burden for our own devs and outside contributors to see the result.

Also related notionally to dev feedback in usnistgov/oscal-content#120 .

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
