### PR TITLE
Issue135 correcting acronyms in titles

### DIFF
--- a/src/nist.gov/SP800-53/rev5/xml/validate-names-etc_SP800-53-catalog.sch
+++ b/src/nist.gov/SP800-53/rev5/xml/validate-names-etc_SP800-53-catalog.sch
@@ -63,7 +63,8 @@
     
     <sch:let name="known-part-names" value="('overview','statement', 'item', 'guidance', 'assessment-objective', 'assessment-method', 'assessment-objects')"/>
     
-    <sch:let name="known-property-names" value="('keywords', 'label', 'sort-id', 'method', 'status', 'aggregates', 'alt-identifier', 'alt-label')"/>
+    <sch:let name="known-property-names" value="('keywords', 'label', 'sort-id', 'method', 'status', 'aggregates', 'alt-identifier', 'alt-label',
+        'implementation-level','contributes-to-assurance')"/>
     
     <sch:pattern id="general">
         <sch:rule context="*[matches(@name,'\S')]">
@@ -99,10 +100,10 @@
 <!-- Ensure all the values of @name given are known.  -->
     <sch:pattern id="occurrences">
         <sch:rule context="o:part[exists(@name)]">
-            <sch:assert test="@name=$known-part-names">@name on part is not recognized: we expect <sch:value-of select="o:or-sequence($known-part-names)"/></sch:assert>
+            <sch:assert test="@name=$known-part-names">@name '<sch:value-of select="@name"/>' on part is not recognized: we expect <sch:value-of select="o:or-sequence($known-part-names)"/></sch:assert>
         </sch:rule>
         <sch:rule context="o:prop[exists(@name)]">
-            <sch:assert test="@name=$known-property-names">@name on property is not recognized: we expect <sch:value-of select="o:or-sequence($known-property-names)"/></sch:assert>
+            <sch:assert test="@name=$known-property-names">@name '<sch:value-of select="@name"/>' on property is not recognized: we expect <sch:value-of select="o:or-sequence($known-property-names)"/></sch:assert>
         </sch:rule>
         
     </sch:pattern>
@@ -215,16 +216,25 @@
         </sch:rule>
     </sch:pattern>
     
-    <sch:pattern id="conversion-quality">
+    <sch:pattern id="element-content-conversions">
         <sch:rule context="o:p|o:li">
             <sch:report test="matches(.,'^\s*\d')"><sch:name/> starts with a numeral</sch:report>
         </sch:rule>
         <sch:rule context="o:b | o:i | o:u | o:a | o:code | o:q">
             <sch:assert test="matches(.,'\S')"><sch:name/> appears without content</sch:assert>
         </sch:rule>
+        <sch:rule context="o:title">
+            <sch:report test="matches(.,'\p{Ps}\p{Ll}')">Title contains an open bracket followed by lower case</sch:report>
+            <sch:report test="matches(.,'(&#x8212;\S|\S&#x8212;)')">Title contains an em dash without whitespace </sch:report>
+            <!--<sch:report test="matches(.,'(/\S|\S/)')">Title contains a slash without whitespace</sch:report>-->
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:pattern id="text-conversions">
         <sch:rule context="*[exists(text()[matches(.,'\S')])]">
             <sch:report test="matches(string(.),'\[Assign')">Check text for dropped paramater ("[Assign")</sch:report>
         </sch:rule>
+        
         
     </sch:pattern>
 


### PR DESCRIPTION
# Committer Notes

Addresses #112. "Gsa" in IA-5(15) is corrected to "GSA", while "NIAP" and "SCRM" are confirmed to be correct (SA-4(7) and SR-2(1).)

Note that since this is an enhancement title, it already appears in all capitals in most renditions, so will look the same.

In the end, only this one new typo was found: other reported issues are either downstream (spreadsheet conversion issues) or have already been corrected. See #112 for analysis.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? **See #112**
- [x] Have you written new tests for your core changes, as applicable? **n/a**
- [x] Have you included examples of how to use your new feature(s)? **n/a**
