### PR TITLE
OSCAL-content patch 1.2.1 release

### DIFF
--- a/.github/workflows/content-artifacts.yml
+++ b/.github/workflows/content-artifacts.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 name: Process Content Artifacts
 env:
-  HOME_REPO: usnistgov/OSCAL
+  HOME_REPO: usnistgov/oscal-content
   # With the default GEN_CONTENT_DIR, the resulting catalogs, profiles, and
   # other example content will end up in the build/generated directory. For
   # checking in finalized content, it goes into build/.., the top-level

--- a/src/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_HIGH-baseline_profile.xml
+++ b/src/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_HIGH-baseline_profile.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model schematypens="http://www.w3.org/2001/XMLSchema" type="application/xml" href="https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_complete_schema.xsd"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         uuid="beade175-48ad-47c0-ac38-e9c2514cba22">
+         uuid="cd073316-7c58-4c34-9f5c-9eb5aa722683">
    <metadata>
-      <title>NIST Special Publication 800-53 Revision 5 HIGH IMPACT BASELINE</title>
-      <last-modified>2023-10-12T00:00:00.000000-04:00</last-modified>
-      <version>Final</version>
+      <title>NIST Special Publication 800-53 Revision 5.1.1 HIGH IMPACT BASELINE</title>
+      <last-modified>2023-12-04T14:55:00.000000-04:00</last-modified>
+      <version>5.1.1+u2</version>
       <oscal-version>1.1.1</oscal-version>
       <role id="creator">
          <title>Document Creator</title>

--- a/src/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_LOW-baseline_profile.xml
+++ b/src/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_LOW-baseline_profile.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model schematypens="http://www.w3.org/2001/XMLSchema" type="application/xml" href="https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_complete_schema.xsd"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         uuid="8742196d-86ba-4e72-a411-28867dab43bb">
+         uuid="b648ca9e-da6d-4159-b28d-f2df9a044137">
    <metadata>
-      <title>NIST Special Publication 800-53 Revision 5 LOW IMPACT BASELINE</title>
-      <last-modified>2023-10-12T00:00:00.000000-04:00</last-modified>
-      <version>Final</version>
+      <title>NIST Special Publication 800-53 Revision 5.1.1 LOW IMPACT BASELINE</title>
+      <last-modified>2023-12-04T14:55:00.000000-04:00</last-modified>
+      <version>5.1.1+u2</version>
       <oscal-version>1.1.1</oscal-version>
       <role id="creator">
          <title>Document Creator</title>

--- a/src/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml
+++ b/src/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model schematypens="http://www.w3.org/2001/XMLSchema" type="application/xml" href="https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_complete_schema.xsd"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         uuid="1019f424-1556-4aa3-9df3-337b97c2c856">
+         uuid="49f45a95-20d1-450a-b4a5-c27ecc335a26">
    <metadata>
-      <title>NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE</title>
-      <last-modified>2023-10-12T00:00:00.000000-04:00</last-modified>
-      <version>Final</version>
+      <title>NIST Special Publication 800-53 Revision 5.1.1 MODERATE IMPACT BASELINE</title>
+      <last-modified>2023-12-04T14:55:00.000000-04:00</last-modified>
+      <version>5.1.1+u2</version>
       <oscal-version>1.1.1</oscal-version>
       <role id="creator">
          <title>Document Creator</title>

--- a/src/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_PRIVACY-baseline_profile.xml
+++ b/src/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_PRIVACY-baseline_profile.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model schematypens="http://www.w3.org/2001/XMLSchema" type="application/xml" href="https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_complete_schema.xsd"?>
 <profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         uuid="66b95dd9-650d-456f-b143-19ae7bb36944">
+         uuid="c8485895-a2f7-46f1-843a-380668cd6fe8">
    <metadata>
-      <title>NIST Special Publication 800-53 Revision 5 PRIVACY BASELINE</title>
-      <last-modified>2023-10-12T00:00:00.000000-04:00</last-modified>
-      <version>Final</version>
+      <title>NIST Special Publication 800-53 Revision 5.1.1 PRIVACY BASELINE</title>
+      <last-modified>2023-12-04T14:55:00.000000-04:00</last-modified>
+      <version>5.1.1+u2</version>
       <oscal-version>1.1.1</oscal-version>
       <role id="creator">
          <title>Document Creator</title>

--- a/src/nist.gov/SP800-53/rev5/xml/oscal-objectives-enhance.xsl
+++ b/src/nist.gov/SP800-53/rev5/xml/oscal-objectives-enhance.xsl
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    exclude-result-prefixes="#all"
+    xpath-default-namespace="http://csrc.nist.gov/ns/oscal/1.0"
+    xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
+    version="3.0">
+    
+    
+    <xsl:output indent="false"/>
+    
+    <!--<xsl:param name="indent" select="2"/>-->
+    
+    <!--<xsl:variable name="indent-ws" select="(1 to xs:integer($indent)) ! ' '"/>-->
+    
+    <!-- <xsl:import href="https://raw.githubusercontent.com/usnistgov/oscal-tools/main/xslt/generate/generate-oscal.xsl"/>-->
+    
+    <!--<xsl:strip-space elements="catalog metadata param control group back-matter prop link part mapping target-resource map usage constraint guideline select remarks description test revisions revision role location party responsible-party address external-id resource citation rlink base64 relationship source target ul ol table tr"/>-->
+    
+    <xsl:mode on-no-match="shallow-copy"/>
+    
+    <xsl:template match="comment() | processing-instruction()"/>
+    
+    <xsl:template priority="101"
+        match="/*/metadata/last-modified/text()">
+        <xsl:text expand-text="true">{ current-dateTime() }</xsl:text>
+    </xsl:template>
+    
+    <xsl:template match="/*">
+        <xsl:text>&#xA;</xsl:text>
+        <xsl:next-match/>
+    </xsl:template>
+    
+    <xsl:template match="/*/@uuid" xmlns:uuid="java:java.util.UUID">
+        <xsl:attribute name="uuid" expand-text="true">{ uuid:randomUUID() }</xsl:attribute>
+    </xsl:template>
+    
+    <xsl:template match="metadata/version">
+        <version>5.2.3</version>
+    </xsl:template>
+    
+    <!-- returns labels that are not followed by other labels designated as the SP800-53A scheme
+         (with padding zeros) - in this data set this gives a single label, an sp800-53a
+         when available or the only label when not -->
+    <xsl:function name="o:label" as="xs:string?">
+        <xsl:param name="n" as="element()"/>
+        <xsl:value-of>
+            <!-- if an sp800-53 classed label is available, return it
+             if not, pad a decimal value with zeros to two places so '1' returns '01.' -->
+            <xsl:variable name="label53a"
+                select="$n/child::prop[@name = 'label'][@class = 'sp800-53a'][1]"/>
+            <xsl:sequence select="$label53a/string(@value)"/>
+            <!-- padding digits here -->
+            <xsl:if test="empty($label53a)">
+                <xsl:analyze-string select="$n/child::prop[@name = 'label'][1]/@value" regex="[0-9]+">
+                    <xsl:matching-substring>
+                        <xsl:value-of select="format-number(number(.), '01')"/>
+                    </xsl:matching-substring>
+                    <xsl:non-matching-substring>
+                        <xsl:value-of select="."/>
+                    </xsl:non-matching-substring>
+                </xsl:analyze-string>
+            </xsl:if>
+        </xsl:value-of>
+            
+    </xsl:function>
+    
+    <xsl:function name="o:long-label" as="xs:string">
+        <xsl:param name="p" as="element()"/>
+        <!--for an 'item' part with a truncated label i.e. '(a)', returns the long label AC-02(a) -->
+        <xsl:variable name="ancestry" select="$p/ancestor-or-self::* except $p/ancestor::control[1]/ancestor::*"/>
+        <xsl:sequence select="string-join($ancestry/o:label(.),'') => replace('\p{P}','')"/>
+    </xsl:function>
+    
+    <xsl:key name="item-by-label" match="part[@name=('statement','item')]" use="o:long-label(.)"/>
+    
+    <!-- strips away bracketed substrings
+          so 'AC-01(a)[2](2)[2]' returns 'AC-01a2' -->
+          
+    <xsl:function name="o:reduce-label" as="xs:string">
+        <xsl:param name="p" as="element()"/>
+        <xsl:variable name="l" select="o:label($p)"/>
+        <xsl:text expand-text="true">{ replace($l,'\[[0-9]+?\]','')  => replace('\p{P}','') }</xsl:text>
+    </xsl:function>
+    
+    <!--<xsl:template match="part[@name=('statement','item')]">
+       <xsl:next-match/>     
+       
+        <xsl:message expand-text="true">Seeing { @name } { @id } being tagged as '{ o:long-label(.) }'</xsl:message>
+    </xsl:template>-->
+    
+    
+<!-- 
+     on assessment-objective #AC-01a.01(a)
+        the reduced label is 'AC-01a.01(a)' linking to '' (0)
+    
+    -->
+    <!-- Each part[@name='assessment-objective'] has a single label -->
+    <xsl:template match="part[@name='assessment-objective']/link"/>
+
+    <xsl:template match="part[@name='assessment-objective']/text()[not(matches(.,'\S'))]">
+        <xsl:if test="empty(following-sibling::*[1]/self::link)">
+            <xsl:next-match/>
+        </xsl:if>
+    </xsl:template>
+    
+
+    <xsl:template match="part[@name='assessment-objective']">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates/>
+            
+
+            <xsl:variable name="part-key" select="o:reduce-label(.)"/>
+            <xsl:variable name="statement-item" select="key('item-by-label',$part-key)"/>
+            
+            <xsl:text>  </xsl:text>
+            <link rel="depends-on" href="#{ $statement-item/@id }"></link>
+            
+            <xsl:if test="empty($statement-item)">
+                <xsl:message expand-text="true">No link made for part '{ o:label(.) }'</xsl:message>
+            </xsl:if>
+            <xsl:copy-of select="text()[last()]"></xsl:copy-of>
+        </xsl:copy>
+        
+        
+    </xsl:template>
+    
+    
+</xsl:stylesheet>

--- a/src/nist.gov/SP800-53/rev5/xml/validate-labels_SP800-53-catalog.sch
+++ b/src/nist.gov/SP800-53/rev5/xml/validate-labels_SP800-53-catalog.sch
@@ -32,7 +32,7 @@
         </sch:rule>
         
         <sch:rule context="oscal:control">
-            <sch:let name="expected-id" value="o:reduce-label(oscal:prop[@name='label'][not(@class='sp800-53a')]/@value)"/>
+           <sch:let name="expected-id" value="oscal:prop[@name='alt-identifier'][@class='sp800-53']/@value ! o:reduce-label(.)"/>
             <sch:assert test="@id = $expected-id">Expected id to be '<sch:value-of select="$expected-id"/>'</sch:assert>
         </sch:rule>
         
@@ -115,7 +115,7 @@
     
     <xsl:function name="o:reduce-label">
         <xsl:param name="what" as="node()"/>
-        <xsl:value-of select="lower-case($what) ! replace(., '\(', '.') ! replace(., '\)', '') ! replace(.,'\.$','')"/>
+        <xsl:value-of select="lower-case($what) ! replace(., '\(', '.') ! replace(., '\)', '') ! replace(.,'\.$','') ! replace(.,'0(\d)','$1')"/>
     </xsl:function>
     
     <xsl:template mode="number-format" priority="1" match="oscal:part[@name='item']">a.</xsl:template>

--- a/src/nist.gov/SP800-53/rev5/xml/validate-names-etc_SP800-53-catalog.sch
+++ b/src/nist.gov/SP800-53/rev5/xml/validate-names-etc_SP800-53-catalog.sch
@@ -114,8 +114,10 @@
     <sch:pattern id="required-items">
         <sch:rule context="o:control">
             <sch:let name="withdrawn" value="o:prop[@name='status']/@value = 'withdrawn'"/>
-            <sch:assert test="o:prop/@name='label'">control must have a child 'prop' with @name='label'</sch:assert>
-            <sch:assert test="o:prop/@name='sort-id'">control must have a child 'prop' with @name='sort-id'</sch:assert>
+           <sch:assert test="count(o:prop[@class='sp800-53']/@name='alt-identifier') eq 1">control must have a child 'prop' with @name='alt-identifier' and @class='sp800-53' (<sch:value-of select="@id"/>)</sch:assert>
+           <sch:assert test="count(o:prop[@class='sp800-53a']/@name='alt-identifier') eq 1">control must have a child 'prop' with @name='alt-identifier' and @class="sp800-53a' (<sch:value-of select="@id"/>)</sch:assert>
+           <sch:assert test="empty(o:prop[@name='label'])">'label' props are not now being used (<sch:value-of select="@id"/>)</sch:assert>
+           <sch:assert test="o:prop/@name='sort-id'">control must have a child 'prop' with @name='sort-id'</sch:assert>
             <sch:assert test="o:part/@name='statement' or $withdrawn">control must have a child 'part' with @name='statement'</sch:assert>
             <!--<sch:assert test="o:part/@name='objective' or $withdrawn">control with name='SP800-53' must have a child 'part' with @name='objective'</sch:assert>-->
         </sch:rule>
@@ -141,15 +143,15 @@
         <!-- pre-empting rules for 53A labels       -->
         <sch:rule context="o:control/o:prop[@name = 'label'][@class='sp800-53a']"/>
         
-        <sch:rule context="o:control/o:control/o:prop[@name = 'label']">
+        <sch:rule context="o:control/o:control/o:prop[@name = 'alt-identifier'][@class='sp800-53']">
             <sch:let name="label-regex" value="'^(AC|AT|AU|CA|CM|CP|IA|IR|MA|MP|PE|PL|PM|PS|PT|RA|SA|SC|SI|SR)\-\d\d?\(\d\d?\)$'"/>
             <!--<sch:assert test="o:singleton(.)">prop with name='label'
                 must be a singleton: no other properties named 'label' may appear in the same
                 context</sch:assert>-->
             <sch:assert test="matches(@value, $label-regex)">prop with name='label' must match regular expression <sch:value-of select="$label-regex"/></sch:assert>
-            <sch:let name="parent-label" value="../../o:prop[@name = 'label'][not(@class='sp800-53a')]"/>
+            <sch:let name="parent-label" value="../../o:prop[@name = 'alt-identifier'][@class='sp800-53']"/>
             <xsl:variable name="formatted-no">
-                <xsl:number count="o:control" format="(1)"/>
+                <xsl:number count="o:control" format="(01)"/>
             </xsl:variable>
             <sch:assert test="@value = (($parent-label/@value) || $formatted-no)">Control enhancement
                 label is inconsistent: we expect <sch:value-of select="$parent-label/@value || $formatted-no"/> here</sch:assert>


### PR DESCRIPTION
# Committer Notes

- addressed issue 226: error in IA-13(03)
- addresses issue 227 by removing extra related links in IA-13(01)(02)(03)
- addresses issue 229 by using consistent structure for the IA-13 ODP p… 
- updated metadata and backmater to include a link to the CPRT SP800-53… 
- addresses issue 224 by replacing labels with alt-identifies and addin… 
- updated root uuid, last-modified, revision history and back-matter.
- added leading zero to PM-7, PM-8 and PM-9 which were missing.
- fix the errors identified during the Schematron validation
- updated one more time the last modified and the uuid
- Updating Schematron rules in view of ongoing changes. (#230)

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
