### PR TITLE
Create negative examples folder

### DIFF
--- a/examples/anti-patterns/README.md
+++ b/examples/anti-patterns/README.md
@@ -1,0 +1,14 @@
+# OSCAL Model-Specific Negative Examples
+
+This directory contains the source files for examples that are valid according
+to the current models but probably should not be. Validation testing, such as
+in the CI pipeline, should include both positive and negative tests and flag
+occurrences of negative examples reported as valid.
+
+The contents of the anti-patterns directory are as follows:
+* [recursive fields](anti-pattern-ap.json) - several assembly definitions contain
+fields that are copies of themselves, leading to infinite-depth recursion. Within the
+Assessment Plan model, `Assessment-part`, `Part`, and `Task` are self-referencing.
+This copy of the IFA AP example contains recursive Task fields several levels deep,
+and should fail validation. Assemblies should use references (foreign keys such as
+UUIDs) instead of copies for fields that refer to themselves.

--- a/examples/anti-patterns/anti-pattern-ap.json
+++ b/examples/anti-patterns/anti-pattern-ap.json
@@ -1,0 +1,203 @@
+{
+  "assessment-plan": {
+    "uuid": "60077e84-e62f-4375-8c6c-b0e0d4560c5f",
+    "metadata": {
+      "title": "IFA GoodRead Assessment Plan",
+      "last-modified": "2024-02-01T13:57:28.355446-04:00",
+      "version": "1.0",
+      "oscal-version": "1.1.2",
+      "roles": [
+        {
+          "id": "assessor",
+          "title": "IFA Security Control Assessor"
+        }
+      ],
+      "parties": [
+        {
+          "uuid": "e7730080-71ce-4b20-bec4-84f33136fd58",
+          "type": "person",
+          "name": "Amy Assessor",
+          "member-of-organizations": [
+            "3a675986-b4ff-4030-b178-e953c2e55d64"
+          ]
+        },
+        {
+          "uuid": "3a675986-b4ff-4030-b178-e953c2e55d64",
+          "type": "organization",
+          "name": "Important Federal Agency",
+          "short-name": "IFA",
+          "links": [
+            {
+              "href": "https://www.ifa.gov",
+              "rel": "website"
+            }
+          ]
+        }
+      ],
+      "responsible-parties": [
+        {
+          "role-id": "assessor",
+          "party-uuids": [
+            "e7730080-71ce-4b20-bec4-84f33136fd58"
+          ]
+        }
+      ]
+    },
+    "import-ssp": {
+      "href": "../3-implementation/ssp.oscal.xml"
+    },
+    "local-definitions": {
+      "activities": [
+        {
+          "uuid": "52277182-1ba3-4cb6-8d96-b1b97aaf9d6b",
+          "title": "Examine System Elements for Least Privilege Design and Implementation",
+          "description": "The activity and it steps will be performed by the assessor and facilitated by owner, ISSO, and product team for the IFA GoodRead system with necessary information and access about least privilege design and implementation of the system's elements: the application, web framework, server, and cloud account infrastructure.",
+          "props": [
+            {
+              "name": "method",
+              "value": "EXAMINE"
+            }
+          ],
+          "steps": [
+            {
+              "uuid": "733e3cbf-e398-46b6-9c02-a2cb534c341e",
+              "title": "Obtain Network Access via VPN to IFA GoodRead Environment",
+              "description": "The assessor will obtain network access with appropriately configured VPN account to see admin frontend to the application for PAO staff, which is only accessible via VPN with an appropriately configured role for PAO staff accounts."
+            },
+            {
+              "uuid": "4ce7e0b4-d69e-4b80-a700-8600b4d4d933",
+              "title": "Obtain Credentials and Access to AwesomeCloud Account for IFA GoodRead System",
+              "description": "The assessor will obtain access to the GoodRead Product Team's AwesomeCloud account with their single sign-on credentials to a read-only assessor role."
+            },
+            {
+              "uuid": "3d0297de-e47b-4360-b9c3-cf5c425f86cd",
+              "title": "Obtain Applcation Access Provided by Product Team",
+              "description": "The assessor will obtain non-privileged account credentials with the PAO staff role to test this role in the application does not permit excessive administrative operations."
+            },
+            {
+              "uuid": "64ca1ef6-3ad4-4747-97c6-40890222463f",
+              "title": "Confirm Load Balancer Blocks Access to Admin Frontend from Internet",
+              "description": "The assessor will confirm that the load balancer for public access does not allow access to Admin Frontend of the application from the Internet."
+            },
+            {
+              "uuid": "715f0592-166f-44f6-bb66-d99623e035dc",
+              "title": "Confirm GoodRead's PAO Role Cannot Manage Users",
+              "description": "The assessor will confirm that user's logged into the GoodRead Application with the PAO staff role cannot add, modify, or disable users from the system."
+            },
+            {
+              "uuid": "4641957b-a0fa-4c61-af1a-d3e9101efe40",
+              "title": "Confirm Django Admin Panel Not Available",
+              "description": "The assessor will confirm with web-based interface and API methods users with the PAO Staff role cannot access the Django admin panel functions and interactively change application's database records."
+            }
+          ],
+          "related-controls": {
+            "control-selections": [
+              {
+                "include-controls": [
+                  {
+                    "control-id": "ac-6.1"
+                  }
+                ]
+              }
+            ]
+          },
+          "responsible-roles": [
+            {
+              "role-id": "assessor",
+              "party-uuids": [
+                "e7730080-71ce-4b20-bec4-84f33136fd58"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "reviewed-controls": {
+      "control-selections": [
+        {
+          "include-controls": [
+            {
+              "control-id": "ac-6.1"
+            }
+          ]
+        }
+      ],
+      "control-objective-selections": [
+        {
+          "include-all": {}
+        }
+      ]
+    },
+    "assessment-subjects": [
+      {
+        "type": "component",
+        "description": "The assessor for the IFA GoodRead Project, including the application and infrastructure for this information system, are within scope of this assessment.",
+        "include-all": {}
+      }
+    ],
+    "tasks": [
+      {
+        "uuid": "b3504d22-0e75-4dd7-9247-618661beba4e",
+        "type": "action",
+        "title": "Examine Least Privilege Design and Implementation",
+        "associated-activities": [
+          {
+            "activity-uuid": "0d243b23-a889-478f-9716-6d4870e56209",
+            "subjects": [
+              {
+                "type": "component",
+                "include-all": {}
+              }
+            ]
+          }
+        ],
+        "responsible-roles": [
+          {
+            "role-id": "assessor"
+          }
+        ],
+        "remarks": "Per IFA's use of NIST SP-800 53A, the assessor, with the support of the owner, information system security officer, and product team for the IFA GoodRead project, will examine least privilege design and implementation with the following:\n\n* list of security functions (deployed in hardware, software, and firmware) and security-relevant information for which access must be explicitly authorized;\n* system configuration settings and associated documentation;\n",
+        "tasks": [
+          {
+            "uuid": "e08ac619-5812-4597-ad03-db50f291ef87",
+            "type": "action",
+            "title": "IFA Alpha",
+            "tasks": [
+              {
+                "uuid": "7488a0b7-d415-489d-854a-97dc80dcafd3",
+                "type": "action",
+                "title": "IFA Beta"
+              },
+              {
+                "uuid": "1dad34fa-bb0d-4ffe-959e-e156c21c16b5",
+                "type": "action",
+                "title": "IFA Gamma",
+                "tasks": [
+                  {
+                    "uuid": "353abaa5-e254-4652-945a-f0d6ecb9c18c",
+                    "type": "action",
+                    "title": "IFA Delta",
+                    "tasks": [
+                      {
+                        "uuid": "bdf23949-2c3f-4bd5-9124-38166472c50a",
+                        "type": "action",
+                        "title": "IFA Epsilon",
+                        "tasks": [
+                          {
+                            "uuid": "bb04743c-34e2-4d26-9da6-8297873cc3e4",
+                            "type": "action",
+                            "title": "IFA Zeta"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Committer Notes

This PR establishes a folder to hold examples that are currently valid (as of OSCAL v1.1.2) but illustrate problems that should be fixed in future versions.  It includes the first such example, an Assessment Plan illustrating a self-cycle in the `tasks` field that permits recursive data, contradicting the goal of models being DAGs.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-content/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-content/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?

This PR does not propose a core feature of OSCAL, it proposes an update to the CI/CD process. The user story is:
* OSCAL maintainers modify CI/CD checks to validate anti-patterns and tag those that *do not* fail validation as issues to be addressed in future versions
* OSCAL maintainers receive a proposed anti-pattern example and determine if it *should not* be accepted as a valid OSCAL file.