### PR TITLE
AI RMF profile examples in XML (rework of #333)

### DIFF
--- a/src/examples/profile/xml/ai-rmf-categories-only_profile.xml
+++ b/src/examples/profile/xml/ai-rmf-categories-only_profile.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="0a9a1f8e-3c2b-4f11-9a4e-6d2f7c81b301">
+  <metadata>
+    <title>AI RMF Categories-Only Example Profile for Demonstration and Testing</title>
+    <published>2026-07-31T00:00:00.000000-00:00</published>
+    <last-modified>2026-07-31T00:00:00.000000-00:00</last-modified>
+    <version>1.0.0</version>
+    <oscal-version>1.2.2</oscal-version>
+    <remarks>
+      <p>This example demonstrates the use of include-all narrowed by exclude-controls with matching patterns, resolved with as-is structuring, against the AI RMF 1.0 catalog. The selection retains the nineteen category-level controls and removes the subcategory-level controls. The selection is illustrative and is not a NIST-recommended, required, or otherwise normative AI RMF baseline.</p>
+    </remarks>
+  </metadata>
+  <import href="../../../nist.gov/AI100-1/ver1/xml/NIST_AI-RMF_v1_catalog.xml">
+    <include-all/>
+    <exclude-controls>
+      <matching pattern="GOVERN_*.*"/>
+      <matching pattern="MANAGE_*.*"/>
+      <matching pattern="MAP_*.*"/>
+      <matching pattern="MEASURE_*.*"/>
+    </exclude-controls>
+  </import>
+  <merge>
+    <as-is>true</as-is>
+  </merge>
+</profile>

--- a/src/examples/profile/xml/ai-rmf-govern-function_profile.xml
+++ b/src/examples/profile/xml/ai-rmf-govern-function_profile.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="1b7c4d20-88f5-4a63-8f0d-5c9e2a1b7742">
+  <metadata>
+    <title>AI RMF GOVERN Function Example Profile for Demonstration and Testing</title>
+    <published>2026-07-31T00:00:00.000000-00:00</published>
+    <last-modified>2026-07-31T00:00:00.000000-00:00</last-modified>
+    <version>1.0.0</version>
+    <oscal-version>1.2.2</oscal-version>
+    <remarks>
+      <p>This example demonstrates include-controls with a matching pattern that selects one of the AI RMF functions in full, resolved with flat structuring. Paired with the categories-only example, which uses as-is structuring over the same catalog, the two illustrate the difference between the two structuring directives. The selection is illustrative and is not a NIST-recommended, required, or otherwise normative AI RMF baseline.</p>
+    </remarks>
+  </metadata>
+  <import href="../../../nist.gov/AI100-1/ver1/xml/NIST_AI-RMF_v1_catalog.xml">
+    <include-controls>
+      <matching pattern="GOVERN_*"/>
+    </include-controls>
+  </import>
+  <merge>
+    <flat/>
+  </merge>
+</profile>


### PR DESCRIPTION
Follow-up to #333, reworked to match the repo conventions (XML in src/) noted in that thread and in the example checklist added in #337.

Four AI RMF community profiles, now authored as XML in src/examples/profile/xml/ (OSCAL 1.2.2), each validated against oscal_complete_schema.xsd:

- ai-rmf-baseline_profile.xml: include-all (72 AI RMF subcategory controls)
- ai-rmf-tier-1-foundational_profile.xml: 18 controls
- ai-rmf-tier-2-customer-facing_profile.xml: 55 controls
- ai-rmf-tier-3-high-risk_profile.xml: include-all, high-risk framing

JSON/YAML are left for the CI/CD pipeline. The catalog JSON, the workflow, and the python tests from the earlier PR are removed. All four are community worked examples (CC0 1.0), marked "Not produced by, endorsed by, or affiliated with NIST".

One point I'd like your guidance on: each profile imports a catalog, and the AI RMF catalog is not in the repo yet. For now the imports use a placeholder path (../../catalog/xml/ai-rmf_catalog.xml). Once an official AI RMF catalog is available here, I will repoint the imports to it.

Into the feature-ai-rmf-profile-examples branch you set up.